### PR TITLE
Add first cut of CME Currency calendars

### DIFF
--- a/pandas_market_calendars/class_registry.py
+++ b/pandas_market_calendars/class_registry.py
@@ -1,3 +1,4 @@
+import inspect
 from pprint import pformat
 
 def _regmeta_instance_factory(cls, name, *args, **kwargs):
@@ -45,10 +46,11 @@ class RegisteryMeta(type):
         return cls
 
     def __init__(cls, name, bases, attr):
-        _regmeta_register_class(cls, cls, name)
-        for b in bases:
-            if hasattr(b, '_regmeta_class_registry'):
-                _regmeta_register_class(b, cls, name)
+        if not inspect.isabstract(cls):
+            _regmeta_register_class(cls, cls, name)
+            for b in bases:
+                if hasattr(b, '_regmeta_class_registry'):
+                    _regmeta_register_class(b, cls, name)
 
         super(RegisteryMeta, cls).__init__(name, bases, attr)
 

--- a/pandas_market_calendars/exchange_calendar_cme.py
+++ b/pandas_market_calendars/exchange_calendar_cme.py
@@ -25,7 +25,7 @@ from pytz import timezone
 
 from .holidays_us import (Christmas, ChristmasEveBefore1993, ChristmasEveInOrAfter1993, USBlackFridayInOrAfter1993,
                           USIndependenceDay, USMartinLutherKingJrAfter1998, USMemorialDay, USJuneteenthAfter2022,
-                          USNationalDaysofMourning, USNewYearsDay)
+                          USNationalDaysofMourning, USNewYearsDay, USThanksgivingFriday)
 from .market_calendar import MarketCalendar
 
 
@@ -292,3 +292,44 @@ class CMEBondExchangeCalendar(MarketCalendar):
             (time(10, tzinfo=self.tz), BondsGoodFridayOpen)
         ]
 
+
+class CMECurrencyExchangeCalendar(CMEBaseExchangeCalendar):
+    aliases = ['CME_Currency']
+
+    # Using CME Globex trading times eg AUD/USD, EUR/GBP, and BRL/USD
+    # https://www.cmegroup.com/markets/fx/g10/australian-dollar.contractSpecs.html
+    # https://www.cmegroup.com/markets/fx/cross-rates/euro-fx-british-pound.contractSpecs.html
+    # https://www.cmegroup.com/markets/fx/emerging-market/brazilian-real.contractSpecs.html
+    # CME "NZD spot" has its own holiday schedule; this is a niche product (via "FX Link") and is not handled in this
+    # class; however, its regular hours follow the same schedule (see
+    # https://www.cmegroup.com/trading/fx/files/fx-product-guide-2021-us.pdf)
+    regular_market_times = {
+        "market_open": ((None, time(17), -1),),  # offset by -1 day
+        "market_close": ((None, time(16, 00)),)
+    }
+
+    @property
+    def name(self):
+        return "CME_Currency"
+
+    @property
+    def special_close_time(self):
+        return time(12, 15)
+
+    @property
+    def regular_holidays(self):
+        return AbstractHolidayCalendar(rules=[
+            USNewYearsDay,
+            GoodFriday,
+            Christmas,
+        ])
+
+    @property
+    def special_closes(self):
+        # Currency futures are typically fully closed or they trade normal hours; Thanksgiving Friday is the exception
+        return [(
+            self.special_close_time,
+            AbstractHolidayCalendar(rules=[
+                USThanksgivingFriday,
+            ])
+        )]

--- a/pandas_market_calendars/exchange_calendar_cme.py
+++ b/pandas_market_calendars/exchange_calendar_cme.py
@@ -24,8 +24,8 @@ from pandas.tseries.holiday import AbstractHolidayCalendar, GoodFriday, USLaborD
 from pytz import timezone
 
 from .holidays_us import (Christmas, ChristmasEveBefore1993, ChristmasEveInOrAfter1993, USBlackFridayInOrAfter1993,
-                          USIndependenceDay, USMartinLutherKingJrAfter1998, USMemorialDay, USNationalDaysofMourning,
-                          USNewYearsDay)
+                          USIndependenceDay, USMartinLutherKingJrAfter1998, USMemorialDay, USJuneteenthAfter2022,
+                          USNationalDaysofMourning, USNewYearsDay)
 from .market_calendar import MarketCalendar
 
 
@@ -91,6 +91,7 @@ class CMEBaseExchangeCalendar(MarketCalendar, ABC):
                 USMartinLutherKingJrAfter1998,
                 USPresidentsDay,
                 USMemorialDay,
+                USJuneteenthAfter2022,
                 USLaborDay,
                 USIndependenceDay,
                 USThanksgivingDay,

--- a/pandas_market_calendars/exchange_calendar_cme.py
+++ b/pandas_market_calendars/exchange_calendar_cme.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 import warnings
-from abc import ABCMeta, abstractmethod
+from abc import ABC, abstractmethod
 
 from datetime import time
 from itertools import chain
@@ -29,9 +29,9 @@ from .holidays_us import (Christmas, ChristmasEveBefore1993, ChristmasEveInOrAft
 from .market_calendar import MarketCalendar
 
 
-class CMEBaseExchangeCalendar(MarketCalendar):
+class CMEBaseExchangeCalendar(MarketCalendar, ABC):
     @property
-    #@abstractmethod  #Would have prefered to keep this class abstract but it fails test_market_calendar.py
+    @abstractmethod
     def name(self):
         """
         Name of the market

--- a/pandas_market_calendars/exchange_calendar_cme.py
+++ b/pandas_market_calendars/exchange_calendar_cme.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 import warnings
-from abc import ABCMeta, abstractmethod
+from abc import ABC, abstractmethod
 
 from datetime import time
 from itertools import chain
@@ -29,7 +29,7 @@ from .holidays_us import (Christmas, ChristmasEveBefore1993, ChristmasEveInOrAft
 from .market_calendar import MarketCalendar
 
 
-class CMEBaseExchangeCalendar(MarketCalendar):
+class CMEBaseExchangeCalendar(MarketCalendar, ABC):
     """
     Base Exchange Calendar for CME.
 
@@ -57,7 +57,7 @@ class CMEBaseExchangeCalendar(MarketCalendar):
     - US Thanksgiving Day
     """
     @property
-    #@abstractmethod  #Would have prefered to keep this class abstract but it fails test_market_calendar.py
+    @abstractmethod
     def name(self):
         """
         Name of the market
@@ -143,7 +143,7 @@ class CMELivestockExchangeCalendar(CMEAgricultureExchangeCalendar):
     aliases = ['CME_Livestock', 'CME_Live_Cattle', 'CME_Feeder_Cattle', 'CME_Lean_Hog', 'CME_Port_Cutout']
 
     regular_market_times = {
-        "market_open": ((None, time(8, 30)),), 
+        "market_open": ((None, time(8, 30)),),
         "market_close": ((None, time(13, 5)),)
     }
 
@@ -179,9 +179,9 @@ class CMELivestockExchangeCalendar(CMEAgricultureExchangeCalendar):
                 ChristmasEveInOrAfter1993,
             ])
         )]
-  
 
-    
+
+
 class CMEEquityExchangeCalendar(CMEBaseExchangeCalendar):
     aliases = ['CME_Equity', 'CBOT_Equity', '/ES', 'S&P500']
 
@@ -197,7 +197,7 @@ class CMEEquityExchangeCalendar(CMEBaseExchangeCalendar):
     @property
     def name(self):
         return "CME_Equity"
-    
+
     @property
     def special_close_time(self):
         return time(12, 30)

--- a/pandas_market_calendars/exchange_calendar_cme.py
+++ b/pandas_market_calendars/exchange_calendar_cme.py
@@ -25,7 +25,7 @@ from pytz import timezone
 
 from .holidays_us import (Christmas, ChristmasEveBefore1993, ChristmasEveInOrAfter1993, USBlackFridayInOrAfter1993,
                           USIndependenceDay, USMartinLutherKingJrAfter1998, USMemorialDay, USJuneteenthAfter2022,
-                          USNationalDaysofMourning, USNewYearsDay)
+                          USNationalDaysofMourning, USNewYearsDay, USThanksgivingFriday)
 from .market_calendar import MarketCalendar
 
 
@@ -315,3 +315,44 @@ class CMEBondExchangeCalendar(MarketCalendar):
             (time(10, tzinfo=self.tz), BondsGoodFridayOpen)
         ]
 
+
+class CMECurrencyExchangeCalendar(CMEBaseExchangeCalendar):
+    aliases = ['CME_Currency']
+
+    # Using CME Globex trading times eg AUD/USD, EUR/GBP, and BRL/USD
+    # https://www.cmegroup.com/markets/fx/g10/australian-dollar.contractSpecs.html
+    # https://www.cmegroup.com/markets/fx/cross-rates/euro-fx-british-pound.contractSpecs.html
+    # https://www.cmegroup.com/markets/fx/emerging-market/brazilian-real.contractSpecs.html
+    # CME "NZD spot" has its own holiday schedule; this is a niche product (via "FX Link") and is not handled in this
+    # class; however, its regular hours follow the same schedule (see
+    # https://www.cmegroup.com/trading/fx/files/fx-product-guide-2021-us.pdf)
+    regular_market_times = {
+        "market_open": ((None, time(17), -1),),  # offset by -1 day
+        "market_close": ((None, time(16, 00)),)
+    }
+
+    @property
+    def name(self):
+        return "CME_Currency"
+
+    @property
+    def special_close_time(self):
+        return time(12, 15)
+
+    @property
+    def regular_holidays(self):
+        return AbstractHolidayCalendar(rules=[
+            USNewYearsDay,
+            GoodFriday,
+            Christmas,
+        ])
+
+    @property
+    def special_closes(self):
+        # Currency futures are typically fully closed or they trade normal hours; Thanksgiving Friday is the exception
+        return [(
+            self.special_close_time,
+            AbstractHolidayCalendar(rules=[
+                USThanksgivingFriday,
+            ])
+        )]

--- a/pandas_market_calendars/exchange_calendar_cme.py
+++ b/pandas_market_calendars/exchange_calendar_cme.py
@@ -24,8 +24,8 @@ from pandas.tseries.holiday import AbstractHolidayCalendar, GoodFriday, USLaborD
 from pytz import timezone
 
 from .holidays_us import (Christmas, ChristmasEveBefore1993, ChristmasEveInOrAfter1993, USBlackFridayInOrAfter1993,
-                          USIndependenceDay, USMartinLutherKingJrAfter1998, USMemorialDay, USNationalDaysofMourning,
-                          USNewYearsDay)
+                          USIndependenceDay, USMartinLutherKingJrAfter1998, USMemorialDay, USJuneteenthAfter2022,
+                          USNationalDaysofMourning, USNewYearsDay)
 from .market_calendar import MarketCalendar
 
 
@@ -69,6 +69,7 @@ class CMEBaseExchangeCalendar(MarketCalendar, ABC):
                 USMartinLutherKingJrAfter1998,
                 USPresidentsDay,
                 USMemorialDay,
+                USJuneteenthAfter2022,
                 USLaborDay,
                 USIndependenceDay,
                 USThanksgivingDay,

--- a/pandas_market_calendars/holidays_us.py
+++ b/pandas_market_calendars/holidays_us.py
@@ -1,4 +1,4 @@
-from dateutil.relativedelta import (MO, TH, TU)
+from dateutil.relativedelta import (MO, TH, TU, FR)
 from pandas import (DateOffset, Timestamp, date_range)
 from pandas.tseries.holiday import (Holiday, nearest_workday, sunday_to_monday)
 from pandas.tseries.offsets import Day
@@ -94,6 +94,10 @@ USThanksgivingDay = Holiday('Thanksgiving',
                             start_date=Timestamp('1942-01-01'),
                             month=11, day=1,
                             offset=DateOffset(weekday=TH(4)))
+USThanksgivingFriday = Holiday('ThanksgivingFriday',
+                               start_date=Timestamp('1942-01-01'),
+                               month=11, day=1,
+                               offset=DateOffset(weekday=FR(4)))
 # http://www.tradingtheodds.com/nyse-full-day-closings/
 USMemorialDayBefore1964 = Holiday(
     'Memorial Day',

--- a/pandas_market_calendars/holidays_us.py
+++ b/pandas_market_calendars/holidays_us.py
@@ -351,3 +351,14 @@ USNationalDaysofMourning = [
     Timestamp('2007-01-02', tz='UTC'),
     Timestamp('2018-12-05', tz='UTC'),
 ]
+
+
+#######################################
+# US Juneteenth (June 19th)
+#######################################
+USJuneteenthAfter2022 = Holiday(
+    'Juneteenth Starting at 2022',
+    start_date=Timestamp('2022-06-19'),
+    month=6, day=19,
+    observance=nearest_workday,
+)

--- a/tests/test_cme_currency_calendar.py
+++ b/tests/test_cme_currency_calendar.py
@@ -1,0 +1,49 @@
+import datetime as dt
+
+import pandas as pd
+import pytz
+
+from pandas_market_calendars.exchange_calendar_cme import CMECurrencyExchangeCalendar
+
+
+def test_time_zone():
+    assert CMECurrencyExchangeCalendar().tz == pytz.timezone('America/Chicago')
+    assert CMECurrencyExchangeCalendar().name == 'CME_Currency'
+
+
+def test_sunday_opens():
+    cme = CMECurrencyExchangeCalendar()
+    schedule = cme.schedule('2020-01-01', '2020-01-31', tz='America/New_York')
+    assert pd.Timestamp('2020-01-12 18:00:00', tz='America/New_York') == schedule.loc['2020-01-13', 'market_open']
+
+
+def test_2022_holidays():
+    cme = CMECurrencyExchangeCalendar()
+    good_dates = cme.valid_days('2022-01-01', '2023-01-10')
+    # Closed holidays
+    # Good Friday 2022-04-15
+    # Christmas (observed): 2022-12-26
+    # New Years Day (obscerved) 2023-01-02
+    for holiday_date in ["2022-04-15", "2022-12-26", "2023-01-02"]:
+        assert pd.Timestamp(holiday_date, tz='UTC') not in good_dates
+
+    # Holidays that currencies are open but many other markets are not
+    # Independence day 2022-07-04
+    # Labour day 2022-09-05
+    # Thanksgiving Thursday 2022-11-24
+    for not_holiday_date in ["2022-07-04", "2022-09-05", "2022-11-24"]:
+        assert pd.Timestamp(not_holiday_date, tz='UTC') in good_dates
+
+
+def test_2022_early_closes():
+    cme = CMECurrencyExchangeCalendar()
+    schedule = cme.schedule('2022-01-01', '2022-12-31')
+    early_closes = cme.early_closes(schedule).index
+
+    # Thanksgiving Friday 2022-11-25
+    for date in ["2022-11-25"]:
+        ts = pd.Timestamp(date)
+        assert ts in early_closes
+
+        market_close = schedule.loc[ts].market_close
+        assert market_close.tz_convert(cme.tz).time() == dt.time(12, 15)


### PR DESCRIPTION
I took the liberty of jumping in.  A few more examples may make the design of the CMEBaseExchangeCalendar easier to settle on.

One thing I am unsure of is how to handle the seemingly sporadic observation of holidays in the currency futures markets.   I based the code in the PR on the 2022 holiday calendars, but in 2021 they are different.  For instance, 2021 Good Friday closed early at 1015 CT whereas 2022 is fully closed; the New Year's weekend in 2021 (i.e., 2021-12-31 through 2022-01-03) was fully open, whereas 2023-01-02 is fully closed.  I don't have any good intuition for what is "normal" without going back through the holiday calendars published previously by the CME.  What is the general expectation for historical accuracy?

One other thing, it looks like holidays_us.py and holidays_nyse.py have a fair bit of duplication, I expect to make it easier for someone to follow the NYSE logic, given how full and complete the NYSE calendar is.  I maintained that pattern adding Juneteenth.   

Very open to feedback!

Cheers