### PR TITLE
Add 2020/2021 holidays to CME FX

### DIFF
--- a/pandas_market_calendars/class_registry.py
+++ b/pandas_market_calendars/class_registry.py
@@ -1,3 +1,4 @@
+import inspect
 from pprint import pformat
 
 def _regmeta_instance_factory(cls, name, *args, **kwargs):
@@ -45,10 +46,11 @@ class RegisteryMeta(type):
         return cls
 
     def __init__(cls, name, bases, attr):
-        _regmeta_register_class(cls, cls, name)
-        for b in bases:
-            if hasattr(b, '_regmeta_class_registry'):
-                _regmeta_register_class(b, cls, name)
+        if not inspect.isabstract(cls):
+            _regmeta_register_class(cls, cls, name)
+            for b in bases:
+                if hasattr(b, '_regmeta_class_registry'):
+                    _regmeta_register_class(b, cls, name)
 
         super(RegisteryMeta, cls).__init__(name, bases, attr)
 

--- a/pandas_market_calendars/exchange_calendar_cme.py
+++ b/pandas_market_calendars/exchange_calendar_cme.py
@@ -25,7 +25,7 @@ from pytz import timezone
 
 from .holidays_us import (Christmas, ChristmasEveBefore1993, ChristmasEveInOrAfter1993, USBlackFridayInOrAfter1993,
                           USIndependenceDay, USMartinLutherKingJrAfter1998, USMemorialDay, USJuneteenthAfter2022,
-                          USNationalDaysofMourning, USNewYearsDay)
+                          USNationalDaysofMourning, USNewYearsDay, USThanksgivingFriday)
 from .market_calendar import MarketCalendar
 
 
@@ -292,3 +292,44 @@ class CMEBondExchangeCalendar(MarketCalendar):
             (time(10, tzinfo=self.tz), BondsGoodFridayOpen)
         ]
 
+
+class CMECurrencyExchangeCalendar(CMEBaseExchangeCalendar):
+    aliases = ['CME_Currency']
+
+    # Using CME Globex trading times eg AUD/USD, EUR/GBP, and BRL/USD
+    # https://www.cmegroup.com/markets/fx/g10/australian-dollar.contractSpecs.html
+    # https://www.cmegroup.com/markets/fx/cross-rates/euro-fx-british-pound.contractSpecs.html
+    # https://www.cmegroup.com/markets/fx/emerging-market/brazilian-real.contractSpecs.html
+    # CME "NZD spot" has its own holiday schedule; this is a niche product (via "FX Link") and is not handled in this
+    # class; however, its regular hours follow the same schedule (see
+    # https://www.cmegroup.com/trading/fx/files/fx-product-guide-2021-us.pdf)
+    regular_market_times = {
+        "market_open": ((None, time(17), -1),),  # offset by -1 day
+        "market_close": ((None, time(16, 00)),)
+    }
+
+    @property
+    def name(self):
+        return "CME_Currency"
+
+    @property
+    def special_close_time(self):
+        return time(12, 15)
+
+    @property
+    def regular_holidays(self):
+        return AbstractHolidayCalendar(rules=[
+            USNewYearsDay,
+            GoodFriday,
+            Christmas,
+        ])
+
+    @property
+    def special_closes(self):
+        # Currency futures are typically fully closed or they trade normal hours; Thanksgiving Friday is the exception
+        return [(
+            self.special_close_time,
+            AbstractHolidayCalendar(rules=[
+                USThanksgivingFriday,
+            ])
+        )]

--- a/pandas_market_calendars/exchange_calendar_cme.py
+++ b/pandas_market_calendars/exchange_calendar_cme.py
@@ -24,8 +24,8 @@ from pandas.tseries.holiday import AbstractHolidayCalendar, GoodFriday, USLaborD
 from pytz import timezone
 
 from .holidays_us import (Christmas, ChristmasEveBefore1993, ChristmasEveInOrAfter1993, USBlackFridayInOrAfter1993,
-                          USIndependenceDay, USMartinLutherKingJrAfter1998, USMemorialDay, USNationalDaysofMourning,
-                          USNewYearsDay)
+                          USIndependenceDay, USMartinLutherKingJrAfter1998, USMemorialDay, USJuneteenthAfter2022,
+                          USNationalDaysofMourning, USNewYearsDay)
 from .market_calendar import MarketCalendar
 
 
@@ -91,6 +91,7 @@ class CMEBaseExchangeCalendar(MarketCalendar):
                 USMartinLutherKingJrAfter1998,
                 USPresidentsDay,
                 USMemorialDay,
+                USJuneteenthAfter2022,
                 USLaborDay,
                 USIndependenceDay,
                 USThanksgivingDay,

--- a/pandas_market_calendars/exchange_calendar_cme.py
+++ b/pandas_market_calendars/exchange_calendar_cme.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import warnings
 from abc import ABC, abstractmethod
 
 from datetime import time
@@ -25,7 +24,7 @@ from pytz import timezone
 
 from .holidays_us import (Christmas, ChristmasEveBefore1993, ChristmasEveInOrAfter1993, USBlackFridayInOrAfter1993,
                           USIndependenceDay, USMartinLutherKingJrAfter1998, USMemorialDay, USJuneteenthAfter2022,
-                          USNationalDaysofMourning, USNewYearsDay, USThanksgivingFriday)
+                          USNationalDaysofMourning, USNewYearsDay)
 from .market_calendar import MarketCalendar
 
 
@@ -293,43 +292,3 @@ class CMEBondExchangeCalendar(MarketCalendar):
         ]
 
 
-class CMECurrencyExchangeCalendar(CMEBaseExchangeCalendar):
-    aliases = ['CME_Currency']
-
-    # Using CME Globex trading times eg AUD/USD, EUR/GBP, and BRL/USD
-    # https://www.cmegroup.com/markets/fx/g10/australian-dollar.contractSpecs.html
-    # https://www.cmegroup.com/markets/fx/cross-rates/euro-fx-british-pound.contractSpecs.html
-    # https://www.cmegroup.com/markets/fx/emerging-market/brazilian-real.contractSpecs.html
-    # CME "NZD spot" has its own holiday schedule; this is a niche product (via "FX Link") and is not handled in this
-    # class; however, its regular hours follow the same schedule (see
-    # https://www.cmegroup.com/trading/fx/files/fx-product-guide-2021-us.pdf)
-    regular_market_times = {
-        "market_open": ((None, time(17), -1),),  # offset by -1 day
-        "market_close": ((None, time(16, 00)),)
-    }
-
-    @property
-    def name(self):
-        return "CME_Currency"
-
-    @property
-    def special_close_time(self):
-        return time(12, 15)
-
-    @property
-    def regular_holidays(self):
-        return AbstractHolidayCalendar(rules=[
-            USNewYearsDay,
-            GoodFriday,
-            Christmas,
-        ])
-
-    @property
-    def special_closes(self):
-        # Currency futures are typically fully closed or they trade normal hours; Thanksgiving Friday is the exception
-        return [(
-            self.special_close_time,
-            AbstractHolidayCalendar(rules=[
-                USThanksgivingFriday,
-            ])
-        )]

--- a/pandas_market_calendars/exchange_calendar_cme.py
+++ b/pandas_market_calendars/exchange_calendar_cme.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 import warnings
-from abc import ABCMeta, abstractmethod
+from abc import ABC, abstractmethod
 
 from datetime import time
 from itertools import chain
@@ -29,7 +29,7 @@ from .holidays_us import (Christmas, ChristmasEveBefore1993, ChristmasEveInOrAft
 from .market_calendar import MarketCalendar
 
 
-class CMEBaseExchangeCalendar(MarketCalendar):
+class CMEBaseExchangeCalendar(MarketCalendar, ABC):
     """
     Base Exchange Calendar for CME.
 
@@ -57,7 +57,7 @@ class CMEBaseExchangeCalendar(MarketCalendar):
     - US Thanksgiving Day
     """
     @property
-    #@abstractmethod  #Would have prefered to keep this class abstract but it fails test_market_calendar.py
+    @abstractmethod
     def name(self):
         """
         Name of the market
@@ -144,7 +144,7 @@ class CMELivestockExchangeCalendar(CMEAgricultureExchangeCalendar):
     aliases = ['CME_Livestock', 'CME_Live_Cattle', 'CME_Feeder_Cattle', 'CME_Lean_Hog', 'CME_Port_Cutout']
 
     regular_market_times = {
-        "market_open": ((None, time(8, 30)),), 
+        "market_open": ((None, time(8, 30)),),
         "market_close": ((None, time(13, 5)),)
     }
 
@@ -180,9 +180,9 @@ class CMELivestockExchangeCalendar(CMEAgricultureExchangeCalendar):
                 ChristmasEveInOrAfter1993,
             ])
         )]
-  
 
-    
+
+
 class CMEEquityExchangeCalendar(CMEBaseExchangeCalendar):
     aliases = ['CME_Equity', 'CBOT_Equity', '/ES', 'S&P500']
 
@@ -198,7 +198,7 @@ class CMEEquityExchangeCalendar(CMEBaseExchangeCalendar):
     @property
     def name(self):
         return "CME_Equity"
-    
+
     @property
     def special_close_time(self):
         return time(12, 30)

--- a/pandas_market_calendars/exchange_calendar_cme_globex_fx.py
+++ b/pandas_market_calendars/exchange_calendar_cme_globex_fx.py
@@ -1,0 +1,48 @@
+from datetime import time
+
+from pandas.tseries.holiday import AbstractHolidayCalendar, GoodFriday
+
+from pandas_market_calendars.exchange_calendar_cme import CMEBaseExchangeCalendar
+from pandas_market_calendars.holidays_us import USNewYearsDay, Christmas, USThanksgivingFriday
+
+
+class CMECurrencyExchangeCalendar(CMEBaseExchangeCalendar):
+    aliases = ['CME_Currency']
+
+    # Using CME Globex trading times eg AUD/USD, EUR/GBP, and BRL/USD
+    # https://www.cmegroup.com/markets/fx/g10/australian-dollar.contractSpecs.html
+    # https://www.cmegroup.com/markets/fx/cross-rates/euro-fx-british-pound.contractSpecs.html
+    # https://www.cmegroup.com/markets/fx/emerging-market/brazilian-real.contractSpecs.html
+    # CME "NZD spot" has its own holiday schedule; this is a niche product (via "FX Link") and is not handled in this
+    # class; however, its regular hours follow the same schedule (see
+    # https://www.cmegroup.com/trading/fx/files/fx-product-guide-2021-us.pdf)
+    regular_market_times = {
+        "market_open": ((None, time(17), -1),),  # offset by -1 day
+        "market_close": ((None, time(16, 00)),)
+    }
+
+    @property
+    def name(self):
+        return "CME_Currency"
+
+    @property
+    def special_close_time(self):
+        return time(12, 15)
+
+    @property
+    def regular_holidays(self):
+        return AbstractHolidayCalendar(rules=[
+            USNewYearsDay,
+            GoodFriday,
+            Christmas,
+        ])
+
+    @property
+    def special_closes(self):
+        # Currency futures are typically fully closed or they trade normal hours; Thanksgiving Friday is the exception
+        return [(
+            self.special_close_time,
+            AbstractHolidayCalendar(rules=[
+                USThanksgivingFriday,
+            ])
+        )]

--- a/pandas_market_calendars/exchange_calendar_cme_globex_fx.py
+++ b/pandas_market_calendars/exchange_calendar_cme_globex_fx.py
@@ -1,9 +1,29 @@
 from datetime import time
 
-from pandas.tseries.holiday import AbstractHolidayCalendar, GoodFriday
+from pandas.tseries.holiday import AbstractHolidayCalendar
 
 from pandas_market_calendars.exchange_calendar_cme import CMEBaseExchangeCalendar
-from pandas_market_calendars.holidays_us import USNewYearsDay, Christmas, USThanksgivingFriday
+from pandas_market_calendars.holidays_cme import (
+    USMartinLutherKingJrAfter1998Before2022,
+    USPresidentsDayBefore2022,
+    GoodFridayBefore2021,
+    GoodFriday2021,
+    GoodFridayAfter2021,
+    USMemorialDay2021AndPrior,
+    USIndependenceDayBefore2022,
+    USLaborDayStarting1887Before2022,
+    USThanksgivingBefore2022,
+    USThanksgivingFriday,
+)
+from pandas_market_calendars.holidays_us import (
+    USNewYearsDay,
+    ChristmasEveInOrAfter1993,
+    Christmas,
+)
+
+_1015 = time(10, 15)
+_1200 = time(12, 0)
+_1215 = time(12, 15)
 
 
 class CMECurrencyExchangeCalendar(CMEBaseExchangeCalendar):
@@ -26,23 +46,31 @@ class CMECurrencyExchangeCalendar(CMEBaseExchangeCalendar):
         return "CME_Currency"
 
     @property
-    def special_close_time(self):
-        return time(12, 15)
-
-    @property
     def regular_holidays(self):
         return AbstractHolidayCalendar(rules=[
             USNewYearsDay,
-            GoodFriday,
+            GoodFridayBefore2021,
+            GoodFridayAfter2021,
             Christmas,
         ])
 
     @property
     def special_closes(self):
-        # Currency futures are typically fully closed or they trade normal hours; Thanksgiving Friday is the exception
-        return [(
-            self.special_close_time,
-            AbstractHolidayCalendar(rules=[
-                USThanksgivingFriday,
-            ])
-        )]
+        """
+        Accurate 2020-2022 inclusive
+        TODO - enhance/verify prior to 2020
+        TODO - Add 2023+ once known
+        """
+        # Source https://www.cmegroup.com/tools-information/holiday-calendar.html
+        return [
+            (_1015, AbstractHolidayCalendar(rules=[GoodFriday2021])),
+            (_1200, AbstractHolidayCalendar(rules=[
+                USMartinLutherKingJrAfter1998Before2022,
+                USPresidentsDayBefore2022,
+                USMemorialDay2021AndPrior,
+                USIndependenceDayBefore2022,
+                USLaborDayStarting1887Before2022,
+                USThanksgivingBefore2022,
+            ])),
+            (_1215, AbstractHolidayCalendar(rules=[USThanksgivingFriday, ChristmasEveInOrAfter1993])),
+        ]

--- a/pandas_market_calendars/holidays_cme.py
+++ b/pandas_market_calendars/holidays_cme.py
@@ -1,0 +1,98 @@
+from dateutil.relativedelta import (MO, FR)
+from dateutil.relativedelta import (TH)
+from pandas import (DateOffset, Timestamp)
+from pandas.tseries.holiday import (Holiday, Easter)
+from pandas.tseries.holiday import (nearest_workday)
+from pandas.tseries.offsets import (Day)
+
+USMartinLutherKingJrAfter1998Before2022 = Holiday(
+    'Dr. Martin Luther King Jr. Day',
+    month=1,
+    day=1,
+    # The US markets didn't observe MLK day as a holiday until 1998.
+    start_date=Timestamp('1998-01-01'),
+    end_date=Timestamp('2021-12-31'),
+    offset=DateOffset(weekday=MO(3)),
+)
+
+USPresidentsDayBefore2022 = Holiday(
+    'President''s Day',
+    start_date=Timestamp('1971-01-01'),
+    end_date=Timestamp('2021-12-31'),
+    month=2, day=1,
+    offset=DateOffset(weekday=MO(3)),
+)
+
+GoodFridayBefore2021 = Holiday(
+    "Good Friday",
+    month=1, day=1,
+    offset=[Easter(), Day(-2)],
+    end_date=Timestamp('2020-12-31'),
+)
+GoodFriday2021 = Holiday(
+    "Good Friday",
+    month=1, day=1,
+    offset=[Easter(), Day(-2)],
+    start_date=Timestamp('2021-01-01'),
+    end_date=Timestamp('2021-12-31'),
+)
+GoodFridayAfter2021 = Holiday(
+    "Good Friday",
+    month=1, day=1,
+    offset=[Easter(), Day(-2)],
+    start_date=Timestamp('2022-01-01'),
+)
+
+USMemorialDay2021AndPrior = Holiday(
+    'Memorial Day',
+    month=5,
+    day=25,
+    start_date=Timestamp('1971-01-01'),
+    end_date=Timestamp('2021-12-31'),
+    offset=DateOffset(weekday=MO(1)),
+)
+
+USIndependenceDayBefore2022 = Holiday(
+    'July 4th',
+    month=7,
+    day=4,
+    start_date=Timestamp('1954-01-01'),
+    end_date=Timestamp('2021-12-31'),
+    observance=nearest_workday,
+)
+
+USLaborDayStarting1887Before2022 = Holiday(
+    "Labor Day",
+    month=9,
+    day=1,
+    start_date=Timestamp("1887-01-01"),
+    end_date=Timestamp('2021-12-31'),
+    offset=DateOffset(weekday=MO(1))
+)
+
+
+USThanksgivingBefore2022 = Holiday(
+    'ThanksgivingFriday',
+    start_date=Timestamp('1942-01-01'),
+    end_date=Timestamp('2021-12-31'),
+    month=11, day=1,
+    offset=DateOffset(weekday=TH(4)),
+)
+USThanksgivingFridayBefore2022 = Holiday(
+    'ThanksgivingFriday',
+    start_date=Timestamp('1942-01-01'),
+    end_date=Timestamp('2021-12-31'),
+    month=11, day=1,
+    offset=DateOffset(weekday=FR(4)),
+)
+USThanksgivingFriday2022AndAfter = Holiday(
+    'ThanksgivingFriday',
+    start_date=Timestamp('2022-01-01'),
+    month=11, day=1,
+    offset=DateOffset(weekday=FR(4)),
+)
+USThanksgivingFriday = Holiday(
+    'ThanksgivingFriday',
+    month=11, day=1,
+    offset=DateOffset(weekday=FR(4)),
+)

--- a/pandas_market_calendars/holidays_us.py
+++ b/pandas_market_calendars/holidays_us.py
@@ -1,4 +1,4 @@
-from dateutil.relativedelta import (MO, TH, TU)
+from dateutil.relativedelta import (MO, TH, TU, FR)
 from pandas import (DateOffset, Timestamp, date_range)
 from pandas.tseries.holiday import (Holiday, nearest_workday, sunday_to_monday)
 from pandas.tseries.offsets import Day
@@ -94,6 +94,10 @@ USThanksgivingDay = Holiday('Thanksgiving',
                             start_date=Timestamp('1942-01-01'),
                             month=11, day=1,
                             offset=DateOffset(weekday=TH(4)))
+USThanksgivingFriday = Holiday('ThanksgivingFriday',
+                               start_date=Timestamp('1942-01-01'),
+                               month=11, day=1,
+                               offset=DateOffset(weekday=FR(4)))
 # http://www.tradingtheodds.com/nyse-full-day-closings/
 USMemorialDayBefore1964 = Holiday(
     'Memorial Day',

--- a/pandas_market_calendars/holidays_us.py
+++ b/pandas_market_calendars/holidays_us.py
@@ -94,10 +94,6 @@ USThanksgivingDay = Holiday('Thanksgiving',
                             start_date=Timestamp('1942-01-01'),
                             month=11, day=1,
                             offset=DateOffset(weekday=TH(4)))
-USThanksgivingFriday = Holiday('ThanksgivingFriday',
-                               start_date=Timestamp('1942-01-01'),
-                               month=11, day=1,
-                               offset=DateOffset(weekday=FR(4)))
 # http://www.tradingtheodds.com/nyse-full-day-closings/
 USMemorialDayBefore1964 = Holiday(
     'Memorial Day',

--- a/pandas_market_calendars/holidays_us.py
+++ b/pandas_market_calendars/holidays_us.py
@@ -351,3 +351,14 @@ USNationalDaysofMourning = [
     Timestamp('2007-01-02', tz='UTC'),
     Timestamp('2018-12-05', tz='UTC'),
 ]
+
+
+#######################################
+# US Juneteenth (June 19th)
+#######################################
+USJuneteenthAfter2022 = Holiday(
+    'Juneteenth Starting at 2022',
+    start_date=Timestamp('2022-06-19'),
+    month=6, day=19,
+    observance=nearest_workday,
+)

--- a/tests/test_cme_currency_calendar.py
+++ b/tests/test_cme_currency_calendar.py
@@ -1,0 +1,49 @@
+import datetime as dt
+
+import pandas as pd
+import pytz
+
+from pandas_market_calendars.exchange_calendar_cme import CMECurrencyExchangeCalendar
+
+
+def test_time_zone():
+    assert CMECurrencyExchangeCalendar().tz == pytz.timezone('America/Chicago')
+    assert CMECurrencyExchangeCalendar().name == 'CME_Currency'
+
+
+def test_sunday_opens():
+    cme = CMECurrencyExchangeCalendar()
+    schedule = cme.schedule('2020-01-01', '2020-01-31', tz='America/New_York')
+    assert pd.Timestamp('2020-01-12 18:00:00', tz='America/New_York') == schedule.loc['2020-01-13', 'market_open']
+
+
+def test_2022_holidays():
+    cme = CMECurrencyExchangeCalendar()
+    good_dates = cme.valid_days('2022-01-01', '2023-01-10')
+    # Closed holidays
+    # Good Friday 2022-04-15
+    # Christmas (observed): 2022-12-26
+    # New Years Day (obscerved) 2023-01-02
+    for holiday_date in ["2022-04-15", "2022-12-26", "2023-01-02"]:
+        assert pd.Timestamp(holiday_date, tz='UTC') not in good_dates
+
+    # Holidays that currencies are open but many other markets are not
+    # Independence day 2022-07-04
+    # Labour day 2022-09-05
+    # Thanksgiving Thursday 2022-11-24
+    for not_holiday_date in ["2022-07-04", "2022-09-05", "2022-11-24"]:
+        assert pd.Timestamp(not_holiday_date, tz='UTC') in good_dates
+
+
+def test_2022_early_closes():
+    cme = CMECurrencyExchangeCalendar()
+    schedule = cme.schedule('2022-01-01', '2022-12-31')
+    early_closes = cme.early_closes(schedule).index
+
+    # Thanksgiving Friday 2022-11-25
+    for date in ["2022-11-25"]:
+        ts = pd.Timestamp(date)
+        assert ts in early_closes
+
+        market_close = schedule.loc[ts].market_close
+        assert market_close.tz_convert(cme.tz).time() == dt.time(12, 15)

--- a/tests/test_exchange_calendar_cme_globex_fx.py
+++ b/tests/test_exchange_calendar_cme_globex_fx.py
@@ -3,7 +3,7 @@ import datetime as dt
 import pandas as pd
 import pytz
 
-from pandas_market_calendars.exchange_calendar_cme import CMECurrencyExchangeCalendar
+from pandas_market_calendars.exchange_calendar_cme_globex_fx import CMECurrencyExchangeCalendar
 
 
 def test_time_zone():

--- a/tests/test_exchange_calendar_cme_globex_fx.py
+++ b/tests/test_exchange_calendar_cme_globex_fx.py
@@ -1,5 +1,3 @@
-import datetime as dt
-
 import pandas as pd
 import pytest
 import pytz
@@ -20,9 +18,30 @@ def test_sunday_opens():
     schedule = cme.schedule('2020-01-01', '2020-01-31')
     assert pd.Timestamp('2020-01-12 17:00:00', tz=TZ) == schedule.loc['2020-01-13', 'market_open']
 
+
 @pytest.mark.parametrize(
     'day_status',
     [
+        # 2020
+        # 2020 Martin Luther King Day (20th = Monday)
+        ('2020-01-17', 'open'), ('2020-01-20', '1200'), ('2020-01-21', 'open'),
+        # 2020 Presidents Day (17th = Monday)
+        ('2020-02-14', 'open'), ('2020-02-17', '1200'), ('2020-02-18', 'open'),
+        # 2020 Good Friday (10th = Friday)
+        ('2020-04-09', 'open'), ('2020-04-10', 'closed'), ('2020-04-13', 'open'),
+        # 2020 Memorial Day (May 25 = Monday)
+        ('2020-05-22', 'open'), ('2020-05-25', '1200'), ('2020-05-26', 'open'),
+        # 2020 Independence Day (4th = Saturday)
+        ('2020-07-02', 'open'), ('2020-07-03', '1200'), ('2020-07-06', 'open'),
+        # 2020 Labor Day (4th = Monday)
+        ('2020-09-04', 'open'), ('2020-09-07', '1200'), ('2020-09-08', 'open'),
+        # 2020 Thanksgiving (26th = Thursday)
+        ('2020-11-25', 'open'), ('2020-11-26', '1200'), ('2020-11-27', '1215'), ('2020-11-30', 'open'),
+        # 2020 Christmas (25th = Friday)
+        ('2020-12-24', '1215'), ('2020-12-25', 'closed'), ('2020-12-28', 'closed'), ('2020-12-29', 'open'),
+        # 2020/21 New Year's (Dec 31 = Thur)
+        ('2020-12-31', 'open'), ('2021-01-01', 'closed'), ('2022-01-04', 'open'),
+
         # 2021
         # 2021 Martin Luther King Day (18th = Monday)
         ('2021-01-15', 'open'), ('2021-01-18', '1200'), ('2021-01-19', 'open'),
@@ -39,9 +58,9 @@ def test_sunday_opens():
         # 2021 Thanksgiving (25th = Thursday)
         ('2021-11-24', 'open'), ('2021-11-25', '1200'), ('2021-11-26', '1215'),
         # 2021 Christmas (25th = Saturday)
-        ('2021-12-22', 'open'), ('2021-12-23', 'closed'), ('2021-12-27', 'open'),
+        ('2021-12-23', 'open'), ('2021-12-24', 'closed'), ('2021-12-27', 'open'),
         # 2021/22 New Year's (Dec 31 = Friday) (unusually this period was fully open)
-        ('2021-12-31', 'open'), ('2022-01-03', 'sunday'), ('2022-01-03', 'open'),
+        ('2021-12-31', 'open'), ('2022-01-03', 'open'), ('2022-01-03', 'open'),
 
         # 2022
         # 2022 Martin Luther King Day (17th = Monday)
@@ -49,7 +68,7 @@ def test_sunday_opens():
         # 2022 President's Day (21st = Monday)
         ('2022-02-18', 'open'), ('2022-02-21', 'open'), ('2022-02-22', 'open'),
         # 2022 Good Friday (15 = Friday)
-        ('2022-04-14', 'open'), ('2022-04-15', 'closed'), ('2021-04-18', 'open'),
+        ('2022-04-14', 'open'), ('2022-04-15', 'closed'), ('2022-04-18', 'open'),
         # 2022 Memorial Day	 (30th = Monday)
         ('2022-05-27', 'open'), ('2022-05-30', 'open'), ('2022-05-31', 'open'),
         # 2022 Juneteenth (20th = Monday)
@@ -62,12 +81,12 @@ def test_sunday_opens():
         ('2022-11-23', 'open'), ('2022-11-24', 'open'), ('2022-11-25', '1215'), ('2022-11-28', 'open'),
         # 2022 Christmas (25 = Sunday)
         ('2022-12-23', 'open'), ('2022-12-26', 'closed'), ('2022-12-27', 'open'),
-        # 2022/23 Christmas (Jan 1 = Sunday)
+        # 2022/23 New Years (Jan 1 = Sunday)
         ('2022-12-30', 'open'), ('2023-01-02', 'closed'), ('2023-01-03', 'open'),
     ],
     ids=lambda x: f'{x[0]} {x[1]}',
 )
-def test_2022_and_prior_holidays(day_status):
+def test_2020_through_2022_and_prior_holidays(day_status):
     day_str = day_status[0]
     day_ts = pd.Timestamp(day_str, tz=TZ)
     expected_status = day_status[1]


### PR DESCRIPTION
@glossner so it turns out that 2022 is quite different than history.  I spot checked a bunch of the old holiday schedules and I think I am getting toward the normal pattern, but I am not sure yet.  If I can, I'll try to go back through the CME published history, but personally I will get more value from other CME calendars being correct from now onwards than the specifics of history.

This adds 2020 and 2021 holidays to the calendar.  

I am curious if my big test_2020_through_2022_and_prior_holidays is understandable or not -- I was trying to simplify it for myself to make it easy to document what the expected is (i.e., read the old schedules, add to the test, then make the test pass).  Feedback clearly welcome.

Cheers